### PR TITLE
Remove icon binaries from extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # mozila
-Mozila addons for Github
+
+Firefox add-on that plays a notification chime when GitHub pull requests you follow become ready for review.
+
+## Features
+
+- Polls the GitHub Received Events API for `ready_for_review` pull request events.
+- Shows a desktop notification and plays an audible chime for each newly ready pull request.
+- Stores GitHub credentials using Firefox Sync so they stay in step across browsers.
+- Provides an options page to configure your GitHub username and personal access token.
+
+## Getting started
+
+1. Generate a GitHub [personal access token](https://github.com/settings/tokens) with the `notifications` scope. Copy the token for later.
+2. Open Firefox and browse to `about:debugging#/runtime/this-firefox`.
+3. Click **Load Temporary Add-on…** and choose the `extension/manifest.json` file from this repository.
+4. The add-on icon will appear in your toolbar. Open its preferences to enter your GitHub username and personal access token.
+5. Click **Test now** to trigger an immediate poll. When someone marks a draft pull request ready for review, you will see a notification and hear the chime.
+
+## Development notes
+
+- The background script polls every minute using the GitHub REST API endpoint `users/:username/received_events`. Only `PullRequestEvent` entries with the `ready_for_review` action generate alerts.
+- Seen event IDs are cached locally to avoid duplicate notifications.
+- The chime is generated with the Web Audio API so no audio asset is required.
+
+## Packaging
+
+To build a distributable `.xpi`, run:
+
+```bash
+web-ext build --source-dir extension
+```
+
+Then upload the generated archive to [addons.mozilla.org](https://addons.mozilla.org/).

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,137 @@
+const browserApi = typeof browser !== "undefined" ? browser : chrome;
+const POLL_INTERVAL_MINUTES = 1;
+const STORAGE_KEYS = {
+  SETTINGS: "settings",
+  SEEN_EVENTS: "seenEvents"
+};
+
+async function getSettings() {
+  const data = await browserApi.storage.sync.get({ [STORAGE_KEYS.SETTINGS]: { token: "", username: "" } });
+  return data[STORAGE_KEYS.SETTINGS];
+}
+
+async function saveSettings(settings) {
+  await browserApi.storage.sync.set({ [STORAGE_KEYS.SETTINGS]: settings });
+}
+
+async function getSeenEvents() {
+  const data = await browserApi.storage.local.get({ [STORAGE_KEYS.SEEN_EVENTS]: [] });
+  return data[STORAGE_KEYS.SEEN_EVENTS];
+}
+
+async function saveSeenEvents(eventIds) {
+  await browserApi.storage.local.set({ [STORAGE_KEYS.SEEN_EVENTS]: eventIds.slice(0, 50) });
+}
+
+function playChime() {
+  try {
+    const context = new (self.AudioContext || self.webkitAudioContext)();
+    const oscillator = context.createOscillator();
+    const gainNode = context.createGain();
+
+    oscillator.type = "sine";
+    oscillator.frequency.setValueAtTime(880, context.currentTime);
+    oscillator.frequency.exponentialRampToValueAtTime(440, context.currentTime + 0.8);
+
+    gainNode.gain.setValueAtTime(0.0001, context.currentTime);
+    gainNode.gain.exponentialRampToValueAtTime(0.2, context.currentTime + 0.1);
+    gainNode.gain.exponentialRampToValueAtTime(0.0001, context.currentTime + 1.0);
+
+    oscillator.connect(gainNode);
+    gainNode.connect(context.destination);
+
+    oscillator.start();
+    oscillator.stop(context.currentTime + 1.0);
+  } catch (error) {
+    console.error("Unable to play chime", error);
+  }
+}
+
+async function notifyReadyForReview(event) {
+  const pr = event.payload.pull_request;
+  const title = `PR ready for review: ${pr.title}`;
+  const message = `${event.actor.login} marked #${pr.number} ready in ${event.repo.name}`;
+
+  await browserApi.notifications.create(event.id, {
+    type: "basic",
+    iconUrl: browserApi.runtime.getURL("icons/icon96.png"),
+    title,
+    message
+  });
+  playChime();
+}
+
+async function fetchReadyEvents(settings) {
+  const headers = {
+    Accept: "application/vnd.github+json"
+  };
+
+  if (settings.token) {
+    headers.Authorization = `token ${settings.token}`;
+  }
+
+  const response = await fetch(`https://api.github.com/users/${encodeURIComponent(settings.username)}/received_events?per_page=50`, {
+    headers
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API responded with ${response.status}`);
+  }
+
+  return response.json();
+}
+
+async function processEvents() {
+  const settings = await getSettings();
+  if (!settings.username) {
+    console.debug("GitHub username not configured; skipping poll.");
+    return;
+  }
+
+  try {
+    const events = await fetchReadyEvents(settings);
+    const seen = await getSeenEvents();
+    const newSeen = Array.from(seen);
+
+    for (const event of events) {
+      if (event.type !== "PullRequestEvent" || event.payload.action !== "ready_for_review") {
+        continue;
+      }
+
+      if (newSeen.includes(event.id)) {
+        continue;
+      }
+
+      await notifyReadyForReview(event);
+      newSeen.unshift(event.id);
+    }
+
+    if (newSeen.length !== seen.length) {
+      await saveSeenEvents(newSeen);
+    }
+  } catch (error) {
+    console.error("Failed to process GitHub events", error);
+  }
+}
+
+browserApi.runtime.onInstalled.addListener(async () => {
+  await browserApi.alarms.clear("poll");
+  browserApi.alarms.create("poll", { periodInMinutes: POLL_INTERVAL_MINUTES });
+  const settings = await getSettings();
+  if (!settings.username) {
+    await saveSettings({ token: "", username: "" });
+  }
+  processEvents();
+});
+
+browserApi.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === "poll") {
+    processEvents();
+  }
+});
+
+browserApi.runtime.onMessage.addListener((message) => {
+  if (message && message.type === "refresh") {
+    processEvents();
+  }
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,25 @@
+{
+  "manifest_version": 2,
+  "name": "GitHub PR Ready Notifier",
+  "version": "1.0.0",
+  "description": "Notifies you with a chime when pull requests you follow become ready for review.",
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": true
+  },
+  "options_ui": {
+    "page": "options.html",
+    "browser_style": true
+  },
+  "permissions": [
+    "storage",
+    "alarms",
+    "notifications",
+    "https://api.github.com/*"
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "pr-ready-notifier@example.com"
+    }
+  }
+}

--- a/extension/options.css
+++ b/extension/options.css
@@ -1,0 +1,80 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  padding: 16px;
+  background: #f9f9fb;
+}
+
+main {
+  max-width: 540px;
+  margin: 0 auto;
+  background: #ffffff;
+  padding: 24px;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+}
+
+h1 {
+  margin-top: 0;
+}
+
+label {
+  display: block;
+  margin-bottom: 16px;
+  font-weight: 600;
+}
+
+input[type="text"],
+input[type="password"] {
+  display: block;
+  width: 100%;
+  margin-top: 4px;
+  padding: 8px;
+  border-radius: 4px;
+  border: 1px solid #c4c4c4;
+  font-size: 14px;
+}
+
+.hint {
+  font-size: 12px;
+  color: #555;
+  margin-top: -8px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+button {
+  background: #1967d2;
+  color: #fff;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+button[type="button"] {
+  background: #5f6368;
+}
+
+button:focus {
+  outline: 2px solid #0b57d0;
+  outline-offset: 2px;
+}
+
+#status {
+  margin-top: 12px;
+  min-height: 18px;
+}
+
+#status.success {
+  color: #0b7a07;
+}
+
+#status.error {
+  color: #b00020;
+}

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>PR Ready Notifier Settings</title>
+  <link rel="stylesheet" href="options.css" />
+</head>
+<body>
+  <main>
+    <h1>GitHub PR Ready Notifier</h1>
+    <p>Enter your GitHub username and a personal access token with the <code>notifications</code> scope so the add-on can see events.</p>
+    <form id="settings-form">
+      <label>
+        GitHub username
+        <input type="text" id="username" required />
+      </label>
+      <label>
+        Personal access token
+        <input type="password" id="token" placeholder="Optional but recommended" />
+      </label>
+      <p class="hint">Tokens are stored locally in Firefox Sync storage.</p>
+      <div class="actions">
+        <button type="submit">Save</button>
+        <button type="button" id="test-button">Test now</button>
+      </div>
+      <p id="status" role="status" aria-live="polite"></p>
+    </form>
+  </main>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,0 +1,36 @@
+const browserApi = typeof browser !== "undefined" ? browser : chrome;
+
+document.addEventListener("DOMContentLoaded", async () => {
+  const form = document.getElementById("settings-form");
+  const usernameInput = document.getElementById("username");
+  const tokenInput = document.getElementById("token");
+  const status = document.getElementById("status");
+  const testButton = document.getElementById("test-button");
+
+  const stored = await browserApi.storage.sync.get({ settings: { username: "", token: "" } });
+  usernameInput.value = stored.settings.username || "";
+  tokenInput.value = stored.settings.token || "";
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const username = usernameInput.value.trim();
+    const token = tokenInput.value.trim();
+
+    if (!username) {
+      status.textContent = "Please enter your GitHub username.";
+      status.className = "error";
+      return;
+    }
+
+    await browserApi.storage.sync.set({ settings: { username, token } });
+    status.textContent = "Settings saved.";
+    status.className = "success";
+    browserApi.runtime.sendMessage({ type: "refresh" });
+  });
+
+  testButton.addEventListener("click", () => {
+    status.textContent = "Checking GitHub…";
+    status.className = "";
+    browserApi.runtime.sendMessage({ type: "refresh" });
+  });
+});


### PR DESCRIPTION
## Summary
- add a Firefox extension that polls GitHub received events for ready-for-review pull requests
- play an audio chime and show notifications when new ready events are detected
- provide an options page for GitHub credentials and document setup in the README
- remove binary icon assets from the extension package

## Testing
- not run (manual)


------
https://chatgpt.com/codex/tasks/task_e_68d77a196c2883338d04188970dac0a5