### PR TITLE
Allow extension to access all web pages

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -15,7 +15,8 @@
     "storage",
     "alarms",
     "notifications",
-    "https://api.github.com/*"
+    "https://api.github.com/*",
+    "<all_urls>"
   ],
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
## Summary
- grant the extension broad host access using `<all_urls>` so it can run on any site

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d79cf38558833391d7ab20f4682cb2