### PR TITLE
Fix invalid keyboard shortcut key name

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -21,7 +21,7 @@
   "commands": {
     "check-now": {
       "suggested_key": {
-        "default": "Ctrl+Shift+."
+        "default": "Ctrl+Shift+Period"
       },
       "description": "Manually check for ready pull requests"
     }


### PR DESCRIPTION
## Summary
- update the command shortcut to use the proper Period key name so Firefox accepts the manifest

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7a526a3c48333b07b374dc11b5987